### PR TITLE
feat: added simple iter methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ type ShardedMapInterface interface {
     Put(key K, val V)
     Has(key K) ok bool
     Del(key K)
+    Keys() []K
+    Iter() <-chan KVPair[K, V]
     Len() int
 }
 ```

--- a/fifo_map.go
+++ b/fifo_map.go
@@ -53,3 +53,11 @@ func (m *FIFOMap[K, V]) Del(key K) {
 func (m *FIFOMap[K, V]) Len() int {
 	return m.currentSize
 }
+
+func (m *FIFOMap[K, V]) Keys() []K {
+	return m.internalMap.Keys()
+}
+
+func (m *FIFOMap[K, V]) Iter() <-chan KVPair[K, V] {
+	return m.internalMap.Iter()
+}

--- a/sharded_map_test.go
+++ b/sharded_map_test.go
@@ -66,3 +66,14 @@ func BenchmarkShardMapGet(b *testing.B) {
 
 	_ = v
 }
+
+func BenchmarkShardMapIter(b *testing.B) {
+	sm := NewShardedMap[int, int](b.N, 1, HashInt)
+	for i := 0; i < b.N; i++ {
+		sm.Put(i, i)
+	}
+	b.ResetTimer()
+	for kv := range sm.Iter() {
+		_ = kv
+	}
+}


### PR DESCRIPTION
Added two methods: `Keys()` and `Iter()` to iterate over kv pairs of the ShardMap and FIFOMap.